### PR TITLE
Unskip test for fallback scenario

### DIFF
--- a/server/image.go
+++ b/server/image.go
@@ -25,10 +25,8 @@ func ResizeImageFromGridfs(originalImage *mgo.GridFile, entry *Entry) (*image.Im
 	if imgErr != nil {
 		// reset pointer and re read the gridfs image
 		originalImage.Seek(0, 0)
-		// now it gets really hacky, since go does not support interlaced pngs
-		// http://code.google.com/p/go/issues/detail?id=6293
-		// we will call imagemagick in order to remove interlacing, and save the image
-		// if this fails as well, there must be something wrong
+
+		//if resizing with go tools fails, a fallback is implemented to use convett
 		unresizedImage, magickError := imageMagickFallback(originalImage)
 
 		if magickError == nil {
@@ -147,7 +145,7 @@ func EncodeImage(targetImage io.Writer, imageData image.Image, imageFormat strin
 	case "jpeg":
 		jpeg.Encode(targetImage, imageData, &jpeg.Options{jpeg.DefaultQuality})
 	case "png":
-	    encoder := png.Encoder{CompressionLevel: png.BestCompression}
+		encoder := png.Encoder{CompressionLevel: png.BestCompression}
 		encoder.Encode(targetImage, imageData)
 	case "gif":
 		gif.Encode(targetImage, imageData, &gif.Options{256, nil, nil})

--- a/server/image_test.go
+++ b/server/image_test.go
@@ -189,7 +189,6 @@ func (s *ImageTestSuite) TestEncodeJpegImage(c *C) {
 
 // TestEncodePngImageInterlaced
 func (s *ImageTestSuite) TestEncodePngImageInterlaced(c *C) {
-	c.Skip("This test won't work as long as png does not support interlacing in go @see http://code.google.com/p/go/issues/detail?id=6293")
 	filename, _ := os.Getwd()
 	testPNG, err := os.Open(filename + "/../testdata/interlaced.png")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
fixes #1 

since this project was upgraded to 1.4 the skipped test now works.
with this commit the fallback to convert on interlaced
png images is not necessary anymore. But the server keeps it as
emergency fallback.