### PR TITLE
Enable inheritance of metadata.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -62,6 +62,18 @@ func addImageMetaData(targetImage *mgo.GridFile, imageData image.Image, imageFor
 		"resizeType":       entry.Type,
 		"size":             fmt.Sprintf("%dx%d", entry.Width, entry.Height)}
 
+	originalMetadata := bson.M{}
+
+	if err := originalImage.GetMeta(&originalMetadata); err != nil {
+		log.Println("Original image data not found.")
+	} else {
+		for k, v := range originalMetadata {
+			if _, exists := metadata[k]; !exists {
+				metadata[k] = v
+			}
+		}
+	}
+
 	targetImage.SetContentType(fmt.Sprintf("image/%s", imageFormat))
 	targetImage.SetMeta(metadata)
 }


### PR DESCRIPTION
If the parent image already has existing metadata
we copy them to the child image.
This is useful if the original image has any license
metadata or exif informations.
Metadata that is especially created for the child image
won't be overwritten.

At the moment this won't work recursively!